### PR TITLE
VCS friendly notebook template

### DIFF
--- a/resources/fileTemplates/internal/Notebook.nb.ft
+++ b/resources/fileTemplates/internal/Notebook.nb.ft
@@ -1,1 +1,4 @@
-Notebook[{}]
+Notebook[{},
+PrivateNotebookOptions->{"FileOutlineCache"->False},
+TrackCellChangeTimes->False
+]


### PR DESCRIPTION
Tracking cell change times and the file outline cache are turned off by default.